### PR TITLE
Add support for more complicated filters

### DIFF
--- a/src/main/java/eu/dissco/virtualcollectionservice/component/ElasticSearchQueryParser.java
+++ b/src/main/java/eu/dissco/virtualcollectionservice/component/ElasticSearchQueryParser.java
@@ -97,12 +97,12 @@ public class ElasticSearchQueryParser {
         .replace("[*]", "")
         .replace("$", "")
         .replace("[", "")
-        .replace("]", "")
+        .replace("]", ".")
         .replace("\"", "");
     if (predicateValue.getFirst() instanceof String) {
-      return sanitizedKey + ".keyword";
+      return sanitizedKey + "keyword";
     } else {
-      return sanitizedKey;
+      return sanitizedKey.substring(0, sanitizedKey.length() - 1);
     }
   }
 }

--- a/src/main/java/eu/dissco/virtualcollectionservice/component/SpecimenEvaluationComponent.java
+++ b/src/main/java/eu/dissco/virtualcollectionservice/component/SpecimenEvaluationComponent.java
@@ -9,6 +9,7 @@ import com.jayway.jsonpath.JsonPath;
 import eu.dissco.virtualcollectionservice.schema.DigitalSpecimen;
 import eu.dissco.virtualcollectionservice.schema.TargetDigitalObjectFilter;
 import eu.dissco.virtualcollectionservice.schema.TargetDigitalObjectFilter.OdsPredicateType;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -73,18 +74,39 @@ public class SpecimenEvaluationComponent {
       String predicateKey, List<Object> predicateValues) {
     if (predicateType.equals(OdsPredicateType.EQUALS.value()) && predicateValues.size() == 1) {
       var result = document.read(predicateKey);
-      return predicateValues.getFirst().equals(result);
+      return matchesPredicate(predicateValues, result);
     } else if (predicateType.equals(OdsPredicateType.NOT.value()) && predicateValues.size() == 1) {
       var result = document.read(predicateKey);
-      return !predicateValues.getFirst().equals(result);
+      return !matchesPredicate(predicateValues, result);
     } else if (
         (predicateType.equals(OdsPredicateType.IN.value()) || predicateType
             .equals(OdsPredicateType.EQUALS.value())) && predicateValues.size() > 1) {
       var result = document.read(predicateKey);
-      return predicateValues.contains(result);
+      return matchPredicateArray(predicateValues, result);
     } else {
       throw new IllegalArgumentException(
           "The predicate type is not supported for local evaluation: " + predicateType);
+    }
+  }
+
+  private static boolean matchPredicateArray(List<Object> predicateValues, Object result) {
+    if (result instanceof ArrayList<?>){
+      for (Object val : (ArrayList<?>) result) {
+        if (predicateValues.contains(val)) {
+          return true;
+        }
+      }
+      return false;
+    } else {
+      return predicateValues.contains(result);
+    }
+  }
+
+  private static boolean matchesPredicate(List<Object> predicateValues, Object result) {
+    if (result instanceof ArrayList<?>){
+      return ((ArrayList<?>) result).contains(predicateValues.getFirst());
+    } else {
+      return predicateValues.getFirst().equals(result);
     }
   }
 }

--- a/src/test/java/eu/dissco/virtualcollectionservice/component/ElasticSearchQueryParserTest.java
+++ b/src/test/java/eu/dissco/virtualcollectionservice/component/ElasticSearchQueryParserTest.java
@@ -12,6 +12,7 @@ import static org.junit.Assert.assertThrows;
 
 import co.elastic.clients.elasticsearch._types.FieldValue;
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import eu.dissco.virtualcollectionservice.schema.OdsHasPredicate;
 import eu.dissco.virtualcollectionservice.schema.TargetDigitalObjectFilter;
 import eu.dissco.virtualcollectionservice.schema.TargetDigitalObjectFilter.OdsPredicateType;
 import java.util.List;
@@ -29,7 +30,7 @@ class ElasticSearchQueryParserTest {
     return Stream.of(
         Arguments.of(new TargetDigitalObjectFilter()
             .withOdsPredicateType(OdsPredicateType.EQUALS)
-            .withOdsPredicateKey("@id")
+            .withOdsPredicateKey("$['@id']")
             .withOdsPredicateValue(SPECIMEN_ID), givenElasticQuery()),
         Arguments.of(givenNotFilter(),
             new Query.Builder().bool(b -> b.mustNot(new Query.Builder().term(
@@ -64,7 +65,26 @@ class ElasticSearchQueryParserTest {
                 new Query.Builder().bool(b2 -> b2.must(m -> m.term(
                     t -> t.field("ods:version")
                         .value(FieldValue.of(2))
-                        .caseInsensitive(true)))).build())).minimumShouldMatch("1")).build()));
+                        .caseInsensitive(true)))).build())).minimumShouldMatch("1")).build()),
+        Arguments.of(    new TargetDigitalObjectFilter()
+        .withOdsPredicateType(OdsPredicateType.AND)
+        .withOdsHasPredicates(List.of(
+            new OdsHasPredicate()
+                .withOdsPredicateType(OdsHasPredicate.OdsPredicateType.EQUALS)
+                .withOdsPredicateKey("$['ods:hasIdentifications'][*]['ods:hasTaxonIdentifications'][*]['dwc:kingdom']")
+                .withOdsPredicateValue("Plantae"),
+            new OdsHasPredicate()
+                .withOdsPredicateType(OdsHasPredicate.OdsPredicateType.EQUALS)
+                .withOdsPredicateKey("$['ods:hasEvents'][*]['ods:hasLocation']['ods:hasGeoreference']['dwc:decimalLatitude']")
+                .withOdsPredicateValue(-41.0983423)
+        )),             new Query.Builder().bool(b -> b.must(List.of(new Query.Builder().bool(
+                b2 -> b2.must(m -> m.term(t -> t.field("ods:hasIdentifications.ods:hasTaxonIdentifications.dwc:kingdom.keyword")
+                    .value(FieldValue.of("Plantae"))
+                    .caseInsensitive(true)))).build(),
+            new Query.Builder().bool(b2 -> b2.must(m -> m.term(
+                t -> t.field("ods:hasEvents.ods:hasLocation.ods:hasGeoreference.dwc:decimalLatitude")
+                    .value(FieldValue.of(-41.0983423))
+                    .caseInsensitive(true)))).build()))).build()));
   }
 
   @ParameterizedTest

--- a/src/test/java/eu/dissco/virtualcollectionservice/component/SpecimenEvaluationComponentTest.java
+++ b/src/test/java/eu/dissco/virtualcollectionservice/component/SpecimenEvaluationComponentTest.java
@@ -54,10 +54,18 @@ class SpecimenEvaluationComponentTest {
             .withOdsPredicateType(OdsPredicateType.OR)
             .withOdsHasPredicates(List.of(
                 new OdsHasPredicate()
-                    .withOdsPredicateType(OdsHasPredicate.OdsPredicateType.EQUALS)
+                    .withOdsPredicateType(OdsHasPredicate.OdsPredicateType.IN)
                     .withOdsPredicateKey("$['ods:hasIdentifications'][*]['ods:hasTaxonIdentifications'][*]['dwc:kingdom']")
                     .withOdsPredicateValues(List.of("plantae", "Plantae"))
-            )), true));
+            )), true),
+        Arguments.of(new TargetDigitalObjectFilter()
+            .withOdsPredicateType(OdsPredicateType.OR)
+            .withOdsHasPredicates(List.of(
+                new OdsHasPredicate()
+                    .withOdsPredicateType(OdsHasPredicate.OdsPredicateType.IN)
+                    .withOdsPredicateKey("$['ods:hasIdentifications'][*]['ods:hasTaxonIdentifications'][*]['dwc:kingdom']")
+                    .withOdsPredicateValues(List.of("Animalia", "animalia"))
+            )), false));
   }
 
   @BeforeEach

--- a/src/test/java/eu/dissco/virtualcollectionservice/component/SpecimenEvaluationComponentTest.java
+++ b/src/test/java/eu/dissco/virtualcollectionservice/component/SpecimenEvaluationComponentTest.java
@@ -47,9 +47,17 @@ class SpecimenEvaluationComponentTest {
             .withOdsHasPredicates(List.of(
                 new OdsHasPredicate()
                     .withOdsPredicateType(OdsHasPredicate.OdsPredicateType.EQUALS)
-                    .withOdsPredicateKey("$['ods:hasEvents'][0]['ods:hasLocation']['dwc:country']")
-                    .withOdsPredicateValue("Netherlands")
-            )), false));
+                    .withOdsPredicateKey("$['ods:hasEvents'][*]['ods:hasLocation']['dwc:country']")
+                    .withOdsPredicateValue("El Salvador")
+            )), true),
+        Arguments.of(new TargetDigitalObjectFilter()
+            .withOdsPredicateType(OdsPredicateType.OR)
+            .withOdsHasPredicates(List.of(
+                new OdsHasPredicate()
+                    .withOdsPredicateType(OdsHasPredicate.OdsPredicateType.EQUALS)
+                    .withOdsPredicateKey("$['ods:hasIdentifications'][*]['ods:hasTaxonIdentifications'][*]['dwc:kingdom']")
+                    .withOdsPredicateValues(List.of("plantae", "Plantae"))
+            )), true));
   }
 
   @BeforeEach


### PR DESCRIPTION
Add support for more complicated filters.
Had to make some changes to the way we parse filterKey's to elastic properties.
Had to make some changes to handle wildcards correctly in the specimenEvaluation

https://naturalis.atlassian.net/browse/DD-2287